### PR TITLE
Fix bug where two objects were being compared for equality

### DIFF
--- a/lib/validate/one.js
+++ b/lib/validate/one.js
@@ -128,5 +128,5 @@ module.exports = function (subject, parameter, opts) {
   // uppercase
   if (parameter.uppercase && is.not.upperCase(subject)) { return err('VALUE.UPPERCASE'); }
 
-  if (subject !== original) { return subject; }
+  if (!_.isEqual(subject, original)) return subject;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleek-validator",
-  "version": "0.5.9",
+  "version": "0.6.1",
   "description": "A validator for the fleek framework",
   "repository": "https://github.com/fleekjs/fleek-validator",
   "main": "lib/validator.js",


### PR DESCRIPTION
When objects were passed as the subject to be validated, they were incorrectly determined to be invalid.

@lan-nguyen91 @johnhof 